### PR TITLE
Fix mobile Safari authentication by rewriting OAuth cookies

### DIFF
--- a/app/api/auth/callback/[provider]/route.ts
+++ b/app/api/auth/callback/[provider]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { rewriteCookieForFrontend } from '@/lib/auth-cookie-utils'
 
 export async function GET(
   request: NextRequest,
@@ -26,18 +27,26 @@ export async function GET(
       const redirectResponse = NextResponse.redirect(location)
       const setCookies = response.headers.getSetCookie?.() ?? []
       for (const cookie of setCookies) {
-        redirectResponse.headers.append('Set-Cookie', cookie)
+        const rewrittenCookie = rewriteCookieForFrontend(cookie)
+        redirectResponse.headers.append('Set-Cookie', rewrittenCookie)
       }
       return redirectResponse
     }
   }
 
-  // Pass through the response
   const body = await response.text()
-  return new NextResponse(body, {
+  const nextResponse = new NextResponse(body, {
     status: response.status,
     headers: {
       'Content-Type': response.headers.get('Content-Type') || 'text/html',
     },
   })
+
+  const setCookies = response.headers.getSetCookie?.() ?? []
+  for (const cookie of setCookies) {
+    const rewrittenCookie = rewriteCookieForFrontend(cookie)
+    nextResponse.headers.append('Set-Cookie', rewrittenCookie)
+  }
+
+  return nextResponse
 }

--- a/app/api/auth/signin/[provider]/route.ts
+++ b/app/api/auth/signin/[provider]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { rewriteCookieForFrontend } from '@/lib/auth-cookie-utils'
 
 export async function GET(
   request: NextRequest,
@@ -24,18 +25,26 @@ export async function GET(
       const redirectResponse = NextResponse.redirect(location)
       const setCookies = response.headers.getSetCookie?.() ?? []
       for (const cookie of setCookies) {
-        redirectResponse.headers.append('Set-Cookie', cookie)
+        const rewrittenCookie = rewriteCookieForFrontend(cookie)
+        redirectResponse.headers.append('Set-Cookie', rewrittenCookie)
       }
       return redirectResponse
     }
   }
 
-  // Pass through the response
   const body = await response.text()
-  return new NextResponse(body, {
+  const nextResponse = new NextResponse(body, {
     status: response.status,
     headers: {
       'Content-Type': response.headers.get('Content-Type') || 'text/html',
     },
   })
+
+  const setCookies = response.headers.getSetCookie?.() ?? []
+  for (const cookie of setCookies) {
+    const rewrittenCookie = rewriteCookieForFrontend(cookie)
+    nextResponse.headers.append('Set-Cookie', rewrittenCookie)
+  }
+
+  return nextResponse
 }

--- a/lib/auth-cookie-utils.ts
+++ b/lib/auth-cookie-utils.ts
@@ -1,0 +1,26 @@
+export function rewriteCookieForFrontend(cookie: string): string {
+  const parts = cookie.split(';').map((part) => part.trim())
+  const rewritten: string[] = []
+
+  for (const part of parts) {
+    const lowerPart = part.toLowerCase()
+    if (lowerPart.startsWith('domain=')) {
+      continue
+    }
+    if (lowerPart === 'samesite=strict') {
+      rewritten.push('SameSite=Lax')
+      continue
+    }
+    rewritten.push(part)
+  }
+
+  if (!rewritten.some((p) => p.toLowerCase().startsWith('samesite='))) {
+    rewritten.push('SameSite=Lax')
+  }
+
+  if (!rewritten.some((p) => p.toLowerCase() === 'secure')) {
+    rewritten.push('Secure')
+  }
+
+  return rewritten.join('; ')
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Sign-in was not working on mobile Safari when deployed. The logs showed WebSocket disconnection errors:

```
WebSocket protocol error: Connection reset without closing handshake: Client disconnected
```

This was caused by authentication cookies from the Convex backend not being properly set on the frontend domain. Mobile Safari's Intelligent Tracking Prevention (ITP) has stricter cookie handling that was blocking the cross-domain cookies.

## Root Cause

The OAuth signin and callback proxy routes were forwarding `Set-Cookie` headers from the Convex backend (`backend.chordwise.janjs.dev`) as-is. These cookies often include:
- A `Domain` attribute pointing to the backend domain
- `SameSite=Strict` which can cause issues during OAuth redirect flows

On mobile Safari, these cookies would not be sent in subsequent requests to the frontend domain, causing authentication to fail.

## Solution

Added a `rewriteCookieForFrontend` utility that transforms cookies from the backend to work properly with the frontend:

1. **Remove domain attribute** - By omitting the `Domain` attribute, the cookie defaults to the frontend domain where it's being set
2. **Convert SameSite=Strict to SameSite=Lax** - OAuth redirects require Lax mode to work correctly
3. **Ensure Secure flag is present** - Required for HTTPS cookies
4. **Apply to all responses** - Both redirect and non-redirect responses now have cookies rewritten

## Changes

- `lib/auth-cookie-utils.ts` - New utility for cookie transformation
- `app/api/auth/callback/[provider]/route.ts` - Apply cookie rewriting to OAuth callback
- `app/api/auth/signin/[provider]/route.ts` - Apply cookie rewriting to OAuth signin

## Testing

After deploying, test sign-in on:
- Mobile Safari (iPhone)
- Mobile Chrome (Android)
- Desktop browsers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbd68-64b7-7572-8341-3e13d3bd393b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbd68-64b7-7572-8341-3e13d3bd393b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

